### PR TITLE
make targets "all" and "clean" phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OBJS := $(patsubst %.cpp,obj/%.o,$(SRCS))
 CPPFLAGS := -Wall -Werror -std=gnu++11 -O3
 LDFLAGS := -lboost_system -lboost_thread -lboost_filesystem
 
+.PHONY: all clean
 all: $(MAIN)
 
 obj/%.o: %.cpp


### PR DESCRIPTION
My make implementaion (makepp) complains when a rule does not generate its target.
Since the targets "all" and "clean" do not actually generate files, they should be marked phony.
I think this syntax works with all versions of make.
