### PR TITLE
Add tw flag for simming guild war offense and defense simultaneously

### DIFF
--- a/sim.cpp
+++ b/sim.cpp
@@ -532,7 +532,8 @@ Results<uint64_t> play(Field* fd)
         _DEBUG_MSG(1, "Stall after %u turns.\n", turn_limit);
         switch (fd->optimization_mode)
         {
-        case OptimizationMode::defense: return {1, 1, 0, 100, 0};
+			//MDJ: Bug returning a win and a loss in defense mode?
+        case OptimizationMode::defense: return {0, 1, 0, 100, 0};
         case OptimizationMode::raid: return {0, 1, 0, raid_damage, 0};
         case OptimizationMode::brawl: return {0, 1, 0, 5, 0};
         default: return {0, 1, 0, 0, 0};

--- a/sim.h
+++ b/sim.h
@@ -54,6 +54,10 @@ struct FinalResults
     result_type wins;
     result_type draws;
     result_type losses;
+	//MDJ
+	result_type wins2;
+	result_type draws2;
+	result_type losses2;
     result_type points;
     result_type sq_points;
     result_type points_lower_bound;

--- a/tyrant.h
+++ b/tyrant.h
@@ -95,12 +95,14 @@ enum gamemode_t
     surge,
 };
 
+//MDJ
 enum class OptimizationMode
 {
     notset,
     winrate,
     defense,
     war,
+	totalwar,
     brawl,
     raid,
 };


### PR DESCRIPTION
Looking through the changes here there are some minor things like places where I added comments that I ended up not making changes in that area of the code in the end but all of the important stuff is in there and the cleanup is minor.

Fort strings had to become global to make this work without changing a bunch of function signatures but since these are only written once the change should be thread safe.

Indexing for the factors in compute_score in total war mode is currently broken, it just uses the first factor in all cases.  This works fine if you don't use unbalanced factors but if someone actually uses that it will probably need to be fixed.  Note that results are pushed back in alternating fashion (offense, defense, offense, defense, etc.) so it is just a matter of figuring out the correct math to get the correct 'findex'.
