### PR TITLE
Fix `heroism` BGE

### DIFF
--- a/sim.cpp
+++ b/sim.cpp
@@ -1048,7 +1048,7 @@ struct PerformAttack
         }
         do_leech<def_cardtype>();
         unsigned valor_value = att_status->skill(valor);
-        if (valor_value > 0 && fd->bg_effects.count(heroism))
+        if (valor_value > 0 && fd->bg_effects.count(heroism) && def_cardtype == CardType::assault && def_status->m_hp <= 0)
         {
             _DEBUG_MSG(1, "Heroism: %s gain %u attack\n", status_description(att_status).c_str(), valor_value);
             att_status->m_attack += valor_value;


### PR DESCRIPTION
Hi andor.

As some ppl on the forum pointed out, there is one thing amiss in the implementation of the `heroism` BGE. Thankfully "othermaciej" pointed out what is wrong and posted the [solution](www.kongregate.com/forums/2468/topics/426677?page=78#posts-9976727) on the forums. I took his commit and made a patch. I already tested it and the simulation results are way more accurate. If you just merge the pull request, ppl can get the fix through your repo.

BTW thanks a ton for creating this. TU would not be the same (or even playable) without it.
